### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Build webchaind in a stock Go builder container
+FROM golang:1.12-alpine as builder
+
+RUN apk add --no-cache make gcc musl-dev linux-headers git bash cargo
+
+ENV GOPATH=/go
+RUN mkdir -p /go/src/github.com/webchain-network/webchaind
+
+ADD . /go/src/github.com/webchain-network/webchaind
+WORKDIR /go/src/github.com/webchain-network/webchaind
+
+RUN make cmd/webchaind
+
+# Pull webchaind into a second stage deploy alpine container
+FROM alpine:latest
+
+RUN apk add --no-cache ca-certificates rust-stdlib
+COPY --from=builder /go/src/github.com/webchain-network/webchaind/bin/webchaind /usr/sbin/
+
+EXPOSE 39573 31440 31440/udp
+ENTRYPOINT ["webchaind"]


### PR DESCRIPTION
This is what one needs in order to build a `webchaind` docker container.

It also serves as an example of how to build `webchaind` with all the required dependencies.

Since `webchaind` still uses `GOPATH`, this uses `GOPATH`.  Apparently `go1.12.x` still supports it.

This will need to be updated to use `go.mod` after `webchaind` itself uses it, but this does the right thing for now.